### PR TITLE
fix(API-162): adding route for user by id and removing token necessit…

### DIFF
--- a/src/domain/user-terms/user-consent.controller.ts
+++ b/src/domain/user-terms/user-consent.controller.ts
@@ -4,18 +4,15 @@ import {
   Param,
   HttpException,
   HttpStatus,
-  UseGuards,
 } from '@nestjs/common';
 import { UserTermsService } from './user-terms.service';
 import { UserTerms } from './user-terms.entity';
-import { AuthGuard } from 'src/infra/auth/auth.guard';
 
 @Controller('user-consent')
 export class UserConsentController {
   constructor(private readonly userTermsService: UserTermsService) {}
 
   @Get('/:id')
-  @UseGuards(AuthGuard)
   async getAllUserTerms(@Param('id') userId: string): Promise<UserTerms[]> {
     try {
       return await this.userTermsService.getUserTermsByUserId(userId);

--- a/src/domain/user/user.controller.ts
+++ b/src/domain/user/user.controller.ts
@@ -61,13 +61,31 @@ const UserSchema = {
 // };
 @Controller('user')
 export class UserController {
-  constructor(private readonly userService: UserService) {}
+  constructor(private readonly userService: UserService) { }
 
   @Get()
   @UseGuards(AuthGuard)
   @ApiBearerAuth()
   async getAllUsers(): Promise<User[]> {
     return await this.userService.getAll();
+  }
+
+  @Get('/id/:id')  // Aqui, o `:id` é o parâmetro capturado
+  @ApiParam({
+    name: 'id',
+    required: true,
+    type: 'string',
+  })
+  async getUserById(@Param('id') userId: string, @Res() res: Response): Promise<Response> {
+    try {
+      const user = await this.userService.getById(userId);
+      if (!user) {
+        return res.status(404).json({ message: 'User not found' });
+      }
+      return res.status(200).json(user);
+    } catch (e) {
+      return res.status(500).json({ message: e.message });
+    }
   }
 
   @Post()

--- a/src/domain/user/user.service.ts
+++ b/src/domain/user/user.service.ts
@@ -27,9 +27,20 @@ export class UserService {
     return await this.userModel.find();
   }
 
-  async getById(userId: string): Promise<User> {
-    return await this.userModel.findById(userId);
-  }
+    async getById(userId: string): Promise<User | null> {
+      try {
+    
+        const user = await this.userModel.findById(new ObjectId(userId));
+    
+        if (!user) {
+          return null;
+        }
+        return user;
+      } catch (error) {
+        console.error('Error finding the user:', error);
+        throw new Error('Error finding the user');
+      }
+    }
 
   async create(user: User): Promise<User> {
     user.password = await hash(user.password, 10);


### PR DESCRIPTION
…y from the user-consent/id route

the new route user/id/:id retrives all data from the user that includes the most recente accepted term and their resctrictions, now the route /user-consent/:id that returns the terms history for a user does not need a token anymore